### PR TITLE
Prevent crashes when some variables are missing

### DIFF
--- a/lib/models/account.dart
+++ b/lib/models/account.dart
@@ -67,11 +67,11 @@ class Account {
         timeReturnAnnual =
             accountPerformanceData['return']['time_return_annual'].toDouble(),
         moneyReturn =
-            accountPerformanceData['return']['money_return'].toDouble(),
+            accountPerformanceData['return']['money_return']?.toDouble() ?? 0,
         moneyReturnColor = getNumberColor(
-            accountPerformanceData['return']['money_return'].toDouble()),
+            accountPerformanceData['return']['money_return']?.toDouble() ?? 0),
         moneyReturnAnnual =
-            accountPerformanceData['return']['money_return_annual'].toDouble(),
+            accountPerformanceData['return']['money_return_annual']?.toDouble() ?? 0,
         volatility = accountPerformanceData['return']['volatility'].toDouble(),
         sharpe =
             accountPerformanceData['return']['time_return_annual'].toDouble() /
@@ -96,7 +96,10 @@ class Account {
         hasActiveRewards = accountInfo['has_active_rewards'],
         feeFreeAmount = accountInfo['fee_free_amount'].toDouble(),
         reconciledUntil = accountInfo['reconciled_until'] != null ? DateTime.parse(accountInfo['reconciled_until']) : null,
-        isReconciledToday = account_operations.isReconciledToday(accountInfo),
+        isReconciledToday = account_operations.isReconciledToday(
+            accountInfo['reconciled_until'] != null
+                ? DateTime.parse(accountInfo['reconciled_until'])
+                : null),
         amountsSeries = account_operations.createAmountsSeries(
             accountPerformanceData['return']['net_amounts'],
             accountPerformanceData['return']['total_amounts']),

--- a/lib/tools/account_operations.dart
+++ b/lib/tools/account_operations.dart
@@ -697,14 +697,15 @@ bool checkPendingTransactions(accountPendingTransactionData) {
   return (hasPendingTransactions);
 }
 
-bool isReconciledToday(accountInfo) {
+bool isReconciledToday(reconciledUntil) {
   // Returns false if the account isn't reconciled with the latest data yet.
   // Checked at build time to show the relevant indicator to the user if needed.
   DateTime today = DateTime.now();
   DateTime todayAtMidnight = DateTime(today.year, today.month, today.day);
   DateTime yesterday = todayAtMidnight.subtract(const Duration(days: 1));
-  DateTime reconciledUntil = DateTime.parse(accountInfo['reconciled_until']);
-
+  if (reconciledUntil == null) {
+    return true;
+  }
   return (reconciledUntil == yesterday);
 }
 

--- a/lib/widgets/not_reconciled_popup.dart
+++ b/lib/widgets/not_reconciled_popup.dart
@@ -26,7 +26,7 @@ class NotReconciledCard extends StatelessWidget {
         children: [
           Expanded(
             child: Text(
-                "${'not_reconciled_popup.not_reconciled_explanation'.tr()}${reconciledUntil.day}/${reconciledUntil.month}/${reconciledUntil.year}.",
+                "${'not_reconciled_popup.not_reconciled_explanation'.tr()}${reconciledUntil.day.toString().padLeft(2, '0')}/${reconciledUntil.month.toString().padLeft(2, '0')}/${reconciledUntil.year}.",
                             style: notReconciledDescriptionTextStyle
                 ),
           ),


### PR DESCRIPTION
* Prevent crash when `money_return` and `money_return_annual` variables are not set
* Prevent possible crash when `reconciled_until` variable is not set
* Improve date formatting in "Not Reconciled" pop-up